### PR TITLE
Stop testing Java 11

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,9 +3,9 @@
  https://github.com/jenkins-infra/pipeline-library/
 */
 buildPlugin(
-  useContainerAgent: true,
-  failFast: false,  
+  forkCount: '1C', // run this number of tests in parallel for faster feedback.  If the number terminates with a 'C', the value will be multiplied by the number of available CPU cores
+  useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
   configurations: [
-    [platform: 'linux', jdk: 11],
-    [platform: 'windows', jdk: 11],
+    [platform: 'linux', jdk: 21],
+    [platform: 'windows', jdk: 17],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -219,7 +219,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <argLine>
-                        -javaagent:"${settings.localRepository}"/org/jmockit/jmockit/${jmockit.version}/jmockit-${jmockit.version}.jar
+                        ${argLine} -javaagent:"${settings.localRepository}"/org/jmockit/jmockit/${jmockit.version}/jmockit-${jmockit.version}.jar
                     </argLine>
                     <useSystemClassLoader>false</useSystemClassLoader>
                 </configuration>


### PR DESCRIPTION
## Stop testing Java 11

Jenkins stopped supporting Java 11 with the release of Jenkins 2.463 (weekly) and Jenkins 2.479.1 (LTS). Most plugins stopped spending `ci.jenkins.io` time to run tests that are specific to Java 11.

Let's save money and time by removing the Java 11 test configuration. It has not found any issues that are not also found with Java 17 and Java 21.

Jenkins plugin BOM still tests with Java 11 on older lines (currently 2.452.x and 2.462.x) and the plugin build will continue to generate Java 11 byte code until the parent pom is upgraded to 5.x and the minimum Jenkins version is upgraded to 2.479.1.

Switches to test Java 17 / Java 21 since to match the test configuration used in the plugin archetype.

### Testing done

None. Rely on `ci.jenkins.io` to test it.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
